### PR TITLE
Cover all regions in GCP for Static IPs cleanup

### DIFF
--- a/crc/gcp/_base.py
+++ b/crc/gcp/_base.py
@@ -1,12 +1,12 @@
 # Copyright (c) Yugabyte, Inc.
 
-# A list of GCP regions
-GCP_REGION_LIST = [
-    "us-east1",
-    "asia-east1",
-    "asia-northeast1",
-    "asia-southeast1",
-    "europe-west1",
-    "us-central1",
-    "us-west1",
-]
+from google.cloud import compute_v1
+
+def get_gcp_regions(project_id):
+    client = compute_v1.RegionsClient()
+    project_id = project_id
+    regions = client.list(project=project_id)
+
+    # Extract region names
+    region_list = [region.name for region in regions]
+    return region_list

--- a/crc/gcp/ip.py
+++ b/crc/gcp/ip.py
@@ -5,7 +5,7 @@ from typing import List
 
 from google.cloud import compute_v1
 
-from crc.gcp._base import GCP_REGION_LIST
+from crc.gcp._base import get_gcp_regions
 from crc.service import Service
 
 
@@ -67,7 +67,7 @@ class IP(Service):
         Delete the IP addresses that match the filter regex and do not match the exception regex.
         It checks if the filter_regex attribute of the class is empty, if so, it returns True because there are no regex set to filter the IPs, so any ip should be considered.
         """
-        for region in GCP_REGION_LIST:
+        for region in get_gcp_regions(self.project_id):
             ips_to_delete = []
 
             # Get all addresses in the region


### PR DESCRIPTION
Currently we only cover below regions
GCP_REGION_LIST = [
    “us-east1”,
    “asia-east1",
    “asia-northeast1”,
    “asia-southeast1",
    “europe-west1”,
    “us-central1",
    “us-west1”,
]
This PR fixes the issue and covers all GCP Regions